### PR TITLE
bump protobuf from 3.8.2  to 6.10.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "js-protobuf-encode-decode",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "authors": [
     "Georgy Chirkov <mail@gich.co>"
   ],
@@ -14,7 +14,7 @@
     "tests"
   ],
   "dependencies": {
-    "protobuf": "~3.8.2",
+    "protobuf": "~6.10.0",
     "normalize.css": "~3.0.2"
   }
 }

--- a/index.html
+++ b/index.html
@@ -32,8 +32,6 @@
         </label>
     </div>
 </section>
-<script src="bower_components/bytebuffer/dist/ByteBufferAB.min.js"></script>
-<script src="bower_components/long/dist/Long.min.js"></script>
 <script src="bower_components/protobuf/dist/ProtoBuf.min.js"></script>
 <script src="js/frontend.js"></script>
 </body>

--- a/js/frontend.js
+++ b/js/frontend.js
@@ -42,7 +42,7 @@
             decoded.value = JSON.stringify(message.decode(payload), null, 2);
         } catch (e) {
             decoded.value = "Error:\n" + e.toString();
-            console.error(e.toString());
+            console.error(e);
         }
     }
 
@@ -52,7 +52,7 @@
             decode();
         } catch (e) {
             decoded.value = "Error:\n" + e.toString();
-            console.error(e.toString());
+            console.error(e);
         }
     }
 
@@ -70,7 +70,7 @@
             encoded.value = '<' + fromUint8Array(buffer) + '>';
         } catch (e) {
             encoded.value = "Error:\n" + e.toString();
-            console.error(e.toString());
+            console.error(e);
         }
     }
 


### PR DESCRIPTION
A bit has changed so I had add `toUint8Array` and `fromUint8Array` to translate the `encoded.value` hex string to a format which protobuf accepts.