### PR TITLE
Don't try decode when syntax changes

### DIFF
--- a/js/frontend.js
+++ b/js/frontend.js
@@ -49,7 +49,6 @@
     function updateProto() {
         try {
             protoRoot = protobuf.parse(proto.value);
-            decode();
         } catch (e) {
             decoded.value = "Error:\n" + e.toString();
             console.error(e);


### PR DESCRIPTION
If one wants to encode, the "decoded" text disappears, and it's quite annoying.